### PR TITLE
Parameterize pom version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Thumbs.db
 *.iml
 
 target/
+
+# vagrant files #
+################
+.vagrant/*

--- a/examples/vagrant/docker-compose-executor.sh
+++ b/examples/vagrant/docker-compose-executor.sh
@@ -1,2 +1,4 @@
-COMPOSE_JAR_NAME=/home/vagrant/marathon/target/docker-compose-executor_0.0.1.jar
+PROJECT_HOME_DIR='/home/vagrant/marathon/'
+PROJECT_VERSION=`mvn -f $PROJECT_HOME_DIR/pom.xml org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }'`
+COMPOSE_JAR_NAME=/home/vagrant/marathon/target/docker-compose-executor_$PROJECT_VERSION.jar
 java -jar ${COMPOSE_JAR_NAME}

--- a/examples/vagrant/provision-dev-cluster.sh
+++ b/examples/vagrant/provision-dev-cluster.sh
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF
@@ -70,6 +71,8 @@ update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 readonly IP_ADDRESS=192.168.33.7
 readonly MESOS_VERSION=0.28.2-2.0.27
 readonly MARATHON_VERSION=1.1.2-1.0.482
+readonly PROJECT_HOME_DIR='/home/vagrant/marathon'
+readonly PROJECT_VERSION=`mvn -f $PROJECT_HOME_DIR/pom.xml org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }'`
 
 
 function install_mesos {
@@ -84,10 +87,13 @@ function install_docker_compose {
   pip install docker-compose
 }
 
+function get_pom_version {
+  mvn -f ${PROJECT_HOME_DIR}/pom.xml org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }'
+}
 
 function build_docker_compose_executor {
   mvn -f /home/vagrant/marathon/pom.xml clean package -U
-  chmod 777 /home/vagrant/marathon/target/docker-compose-executor_0.0.1.jar
+  chmod 777 /home/vagrant/marathon/target/docker-compose-executor_${PROJECT_VERSION}.jar
 }
 
 function install_cluster_config {


### PR DESCRIPTION
This PR parametarizes the expected version of the `docker_compose_executor-${version}.jar`. Currently it is hardcoded and this introduces a change to grab the current version based on the pom.xml in the root of the project. Let me know if this is misguided or if anything should be changed, tweaked or redone here! Cool project.

This attempts to address issue #15.